### PR TITLE
Separate admin API server URIs

### DIFF
--- a/assets.tf
+++ b/assets.tf
@@ -38,7 +38,7 @@ resource "template_dir" "manifests" {
     apiserver_port         = "${var.apiserver_port}"
 
     ca_cert            = "${base64encode(var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate)}"
-    ca_key            = "${base64encode(var.ca_private_key == "" ? join(" ", tls_private_key.kube-ca.*.private_key_pem) : var.ca_private_key)}"
+    ca_key             = "${base64encode(var.ca_private_key == "" ? join(" ", tls_private_key.kube-ca.*.private_key_pem) : var.ca_private_key)}"
     server             = "${format("https://%s:%s", element(var.api_servers, 0), var.apiserver_port)}"
     apiserver_key      = "${base64encode(tls_private_key.apiserver.private_key_pem)}"
     apiserver_cert     = "${base64encode(tls_locally_signed_cert.apiserver.cert_pem)}"
@@ -81,6 +81,14 @@ data "template_file" "kubeconfig-kubelet" {
   }
 }
 
+# If var.api_servers_external isn't set, use var.api_servers.
+# This is for supporting separate API server URLs for external clients in a backward-compatible way.
+# The use of split() and join() here is because Terraform's conditional operator ('?') cannot be
+# used with lists.
+locals {
+  api_servers_external = "${split(",", join(",", var.api_servers_external) == "" ? join(",", var.api_servers) : join(",", var.api_servers_external))}"
+}
+
 data "template_file" "kubeconfig-admin" {
   template = "${file("${path.module}/resources/kubeconfig-admin")}"
 
@@ -89,6 +97,6 @@ data "template_file" "kubeconfig-admin" {
     ca_cert      = "${base64encode(var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate)}"
     kubelet_cert = "${base64encode(tls_locally_signed_cert.admin.cert_pem)}"
     kubelet_key  = "${base64encode(tls_private_key.admin.private_key_pem)}"
-    server       = "${format("https://%s:%s", element(var.api_servers, 0), var.apiserver_port)}"
+    server       = "${format("https://%s:%s", element(local.api_servers_external, 0), var.apiserver_port)}"
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -79,3 +79,7 @@ output "kubelet_key" {
 output "server" {
   value = "${format("https://%s:%s", element(var.api_servers, 0), var.apiserver_port)}"
 }
+
+output "server_admin" {
+  value = "${format("https://%s:%s", element(local.api_servers_external, 0), var.apiserver_port)}"
+}

--- a/tls-k8s.tf
+++ b/tls-k8s.tf
@@ -68,6 +68,7 @@ resource "tls_cert_request" "apiserver" {
 
   dns_names = [
     "${var.api_servers}",
+    "${var.api_servers_external}",
     "kubernetes",
     "kubernetes.default",
     "kubernetes.default.svc",

--- a/variables.tf
+++ b/variables.tf
@@ -4,8 +4,15 @@ variable "cluster_name" {
 }
 
 variable "api_servers" {
-  description = "List of URLs used to reach kube-apiserver"
+  description = "List of URLs used to reach kube-apiserver from within the cluster"
   type        = "list"
+}
+
+# When not set, the value of var.api_servers will be used.
+variable "api_servers_external" {
+  description = "List of URLs used to reach kube-apiserver from an external network"
+  type        = "list"
+  default     = []
 }
 
 variable "etcd_servers" {


### PR DESCRIPTION
This PR adds a new variable called `var.api_servers_admin`. Its purpose is to allow the caller of this module to specify a different API server URI for *humans* than the URI used by *k8s components* (mainly kubelets) to talk to the API server.

The main use case for this is - running a k8s cluster where the nodes communicate with each other over private IPs while accessing the cluster for management over a public IP.