### PR TITLE
Allow to add public IP addresses to API server certificates

### DIFF
--- a/tls-k8s.tf
+++ b/tls-k8s.tf
@@ -59,9 +59,7 @@ resource "tls_cert_request" "apiserver" {
     "kubernetes.default.svc.${var.cluster_domain_suffix}",
   ]
 
-  ip_addresses = [
-    "${cidrhost(var.service_cidr, 1)}",
-  ]
+  ip_addresses = ["${concat(list(cidrhost(var.service_cidr, 1)), var.api_servers_ips)}"]
 }
 
 resource "tls_locally_signed_cert" "apiserver" {

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,12 @@ variable "api_servers_external" {
   default     = []
 }
 
+variable "api_servers_ips" {
+  description = "List of additional IPv4 addresses to be included in the kube-apiserver TLS certificate"
+  type        = "list"
+  default     = []
+}
+
 variable "etcd_servers" {
   description = "List of URLs used to reach etcd servers."
   type        = "list"


### PR DESCRIPTION
 When connecting to the API server through the public IP address
    it did not work because the certificate did not include this IP.
    Including the public IP on demand in addition to the internal IP
    solves this issue.