### PR TITLE
psp: Update restricted PSP

### DIFF
--- a/resources/manifests/psp-restricted.yaml
+++ b/resources/manifests/psp-restricted.yaml
@@ -30,10 +30,7 @@ spec:
   hostPID: false
   runAsUser:
     # Require the container to run without root privileges.
-    rule: 'MustRunAs'
-    ranges:
-    - min: 1
-      max: 99999
+    rule: 'MustRunAsNonRoot'
   seLinux:
     rule: 'RunAsAny'
   supplementalGroups:


### PR DESCRIPTION
This commit updates the PSP to run the container as any UID except 0.
Hence changing the `runAsUser` rule to `MustRunAsNonRoot`. Earlier a
fixed range was allocated.