### PR TITLE
psp: Allow privileged PSP for kubelet

### DIFF
--- a/resources/manifests/psp-privileged.yaml
+++ b/resources/manifests/psp-privileged.yaml
@@ -63,3 +63,21 @@ subjects:
 - kind: Group
   name: system:serviceaccounts:kube-system
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: privileged-psp-kubelet
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: privileged-psp
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: system:nodes
+- kind: User
+  apiGroup: rbac.authorization.k8s.io
+  # Legacy node ID
+  name: kubelet


### PR DESCRIPTION
Earlier the kubelet on controller threw errors like following:

```bash
$ journalctl -u kubelet
Jun 19 13:43:51 kosy-controller-0 kubelet-wrapper[918]: E0619 13:43:51.056964     918 kubelet.go:1639] Failed creating a
mirror pod for "pod-checkpointer-vwl9d-kosy-controller-0_kube-system(8a35ab15c4ffe99051aae0030b1e5a20)": pods
"pod-checkpointer-vwl9d-kosy-controller-0" is forbidden: unable to validate against any pod security policy:
[spec.securityContext.hostNetwork: Invalid value: true: Host network is not allowed to be used spec.volumes[0]:
Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[1]: Invalid value: "hostPath":
hostPath volumes are not allowed to be used spec.volumes[2]: Invalid value: "hostPath": hostPath volumes are not allowed
to be used spec.volumes[3]: Invalid value: "hostPath": hostPath volumes are not allowed to be used]
```

This caused `kubelet` to not create the static pod's mirror pod in `apiserver`.

```console
$ kubectl get pods -n kube-system | grep check
NAME                                       READY   STATUS    RESTARTS   AGE
pod-checkpointer-vwl9d                     1/1     Running   0          21s
```

But after allowing the kubelet access to the privileged PSP, it was able to create mirror pod.

```console
$ kubectl get pods -n kube-system | grep check
NAME                                       READY   STATUS    RESTARTS   AGE
pod-checkpointer-vwl9d                     1/1     Running   0          17m
pod-checkpointer-vwl9d-kosy-controller-0   1/1     Running   0          34s
```


This was never a problem functionality wise. The kubelet would always create a static pod, but was unable to register it as a mirror pod with apiserver. Hence we saw those errors on `kubelet`.
