### PR TITLE
Create/Modify psp for pod-checkpointer

### DIFF
--- a/resources/manifests/kubelet-pod-checkpointer-psp-role-binding.yaml
+++ b/resources/manifests/kubelet-pod-checkpointer-psp-role-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubelet-pod-checkpointer-psp
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-checkpointer-psp
+subjects:
+- kind: Group
+  name: system:nodes
+  apiGroup: rbac.authorization.k8s.io

--- a/resources/manifests/pod-checkpointer-cluster-role.yaml
+++ b/resources/manifests/pod-checkpointer-cluster-role.yaml
@@ -9,3 +9,4 @@ rules:
       - nodes/proxy
     verbs:
       - get
+

--- a/resources/manifests/pod-checkpointer-psp.yaml
+++ b/resources/manifests/pod-checkpointer-psp.yaml
@@ -1,0 +1,33 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  # https://kubernetes.io/docs/concepts/policy/pod-security-policy/#policy-order
+  # If the pod must be defaulted or mutated, the first PodSecurityPolicy (ordered by name) to allow the pod is selected.
+  name: pod-checkpointer-restricted
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+spec:
+  privileged: false
+  allowPrivilegeEscalation: true
+  # Allow core volume types.
+  volumes:
+  - 'configMap'
+  - 'hostPath'
+  - 'secret'
+  hostNetwork: true
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: false
+  allowedHostPaths:
+  - pathPrefix: "/etc/kubernetes"
+  - pathPrefix: "/var/run"
+  - pathPrefix: "/etc/checkpointer"

--- a/resources/manifests/pod-checkpointer-role-binding.yaml
+++ b/resources/manifests/pod-checkpointer-role-binding.yaml
@@ -11,3 +11,17 @@ subjects:
 - kind: ServiceAccount
   name: pod-checkpointer
   namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-checkpointer-psp
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-checkpointer-psp
+subjects:
+- kind: ServiceAccount
+  name: pod-checkpointer
+  namespace: kube-system

--- a/resources/manifests/pod-checkpointer-role.yaml
+++ b/resources/manifests/pod-checkpointer-role.yaml
@@ -10,3 +10,15 @@ rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["secrets", "configmaps"]
   verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-checkpointer-psp
+  namespace: kube-system
+rules:
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs:     ['use']
+    resourceNames:
+    - pod-checkpointer-restricted


### PR DESCRIPTION
This PR creates psp for pod-checkpointer to fix this kind of error thrown by kubelet on the controller:

```
Failed creating a mirror pod for "pod-checkpointer-...":
pods "pod-checkpointer-..." is forbidden: unable to validate against any pod security policy:
...Host network is not allowed to be used spec.volumes
```

Please read this [PR discussion](https://github.com/kinvolk/terraform-render-bootkube/pull/14) for more context. Thoughts/concerns/feedback/better alternative suggestions are welcome

**To test:**
* Change this [source](https://github.com/kinvolk/lokomotive-kubernetes/blob/master/packet/flatcar-linux/kubernetes/bootkube.tf#L2) to my branch's reference (commit id) 
* Create a cluster on Packet 
* Verify that pod-checkpointer and it's mirror pod are running.
```
 kubectl get pods -n kube-system 
NAME                                       READY   STATUS    RESTARTS   AGE
...
pod-checkpointer-648sp                     1/1     Running   0          5m5s
pod-checkpointer-648sp-kosy-controller-0   1/1     Running   0          4m28s
```
* Verify that kubelet is not throwing errors with regards to pod-checkpointer
```
journalctl -f -u kubelet
```
* Delete both pod-checkpointer static pod and it's mirror pod.
* Check that they get recreated again.
* Verify that the psp they both use is `pod-checkpointer-restricted`
```
 kubectl get -n kube-system pods pod-checkpointer-jn64k -o yaml | grep psp
    kubernetes.io/psp: pod-checkpointer-restricted

kubectl get -n kube-system pods pod-checkpointer-jn64k-kosy-controller-0 -o yaml | grep psp 
    kubernetes.io/psp: pod-checkpointer-restricted

```
There's also a TL;DR summary of the decision for why we have the current iteration here https://github.com/kinvolk/terraform-render-bootkube/pull/15#issuecomment-505868400.

**Question:** What is a practical way to test with disaster recovery? :thinking: 
**A more important question:** Security-wise, what's your take on this PR? 