### PR TITLE
Ignore changes of path.module

### DIFF
--- a/assets.tf
+++ b/assets.tf
@@ -14,6 +14,10 @@ resource "template_dir" "bootstrap-manifests" {
     trusted_certs_dir = "${var.trusted_certs_dir}"
     apiserver_port    = "${var.apiserver_port}"
   }
+
+  lifecycle {
+    ignore_changes = ["source_dir"]
+  }
 }
 
 # Self-hosted Kubernetes manifests
@@ -53,6 +57,10 @@ resource "template_dir" "manifests" {
     aggregation_ca_cert     = "${var.enable_aggregation == "true" ? base64encode(join(" ", tls_self_signed_cert.aggregation-ca.*.cert_pem)) : ""}"
     aggregation_client_cert = "${var.enable_aggregation == "true" ? base64encode(join(" ", tls_locally_signed_cert.aggregation-client.*.cert_pem)) : ""}"
     aggregation_client_key  = "${var.enable_aggregation == "true" ? base64encode(join(" ", tls_private_key.aggregation-client.*.private_key_pem)) : ""}"
+  }
+
+  lifecycle {
+    ignore_changes = ["source_dir"]
   }
 }
 

--- a/conditional.tf
+++ b/conditional.tf
@@ -11,6 +11,10 @@ resource "template_dir" "flannel-manifests" {
 
     pod_cidr = "${var.pod_cidr}"
   }
+
+  lifecycle {
+    ignore_changes = ["source_dir"]
+  }
 }
 
 resource "template_dir" "calico-manifests" {
@@ -24,12 +28,16 @@ resource "template_dir" "calico-manifests" {
 
     network_mtu                     = "${var.network_mtu}"
     network_encapsulation           = "${indent(2, var.network_encapsulation == "vxlan" ? "vxlanMode: Always" : "ipipMode: Always")}"
-    ipip_enabled                   = "${var.network_encapsulation == "ipip" ? true : false}"
-    ipip_readiness                 = "${var.network_encapsulation == "ipip" ? indent(16, "- --bird-ready") : ""}"
+    ipip_enabled                    = "${var.network_encapsulation == "ipip" ? true : false}"
+    ipip_readiness                  = "${var.network_encapsulation == "ipip" ? indent(16, "- --bird-ready") : ""}"
     vxlan_enabled                   = "${var.network_encapsulation == "vxlan" ? true : false}"
     network_ip_autodetection_method = "${var.network_ip_autodetection_method}"
     pod_cidr                        = "${var.pod_cidr}"
     enable_reporting                = "${var.enable_reporting}"
+  }
+
+  lifecycle {
+    ignore_changes = ["source_dir"]
   }
 }
 
@@ -43,5 +51,9 @@ resource "template_dir" "kube-router-manifests" {
     flannel_cni_image = "${var.container_images["flannel_cni"]}"
 
     network_mtu = "${var.network_mtu}"
+  }
+
+  lifecycle {
+    ignore_changes = ["source_dir"]
   }
 }


### PR DESCRIPTION
`${path.module}` is unique for every terraform checkout. Every time I apply this module after someone else there are spam associated with template_dir's source_dir.

This change silences the diff warning as suggested by https://github.com/hashicorp/terraform/issues/7613.