### PR TITLE
Certificates: Parameterize the certs validity

### DIFF
--- a/tls-aggregation.tf
+++ b/tls-aggregation.tf
@@ -28,7 +28,7 @@ resource "tls_self_signed_cert" "aggregation-ca" {
   }
 
   is_ca_certificate     = true
-  validity_period_hours = 8760
+  validity_period_hours = "${var.certs_validity_period_hours}"
 
   allowed_uses = [
     "key_encipherment",
@@ -81,7 +81,7 @@ resource "tls_locally_signed_cert" "aggregation-client" {
   ca_private_key_pem = "${tls_private_key.aggregation-ca.private_key_pem}"
   ca_cert_pem        = "${tls_self_signed_cert.aggregation-ca.cert_pem}"
 
-  validity_period_hours = 8760
+  validity_period_hours = "${var.certs_validity_period_hours}"
 
   allowed_uses = [
     "key_encipherment",

--- a/tls-etcd.tf
+++ b/tls-etcd.tf
@@ -81,7 +81,7 @@ resource "tls_self_signed_cert" "etcd-ca" {
   }
 
   is_ca_certificate     = true
-  validity_period_hours = 8760
+  validity_period_hours = "${var.certs_validity_period_hours}"
 
   allowed_uses = [
     "key_encipherment",
@@ -124,7 +124,7 @@ resource "tls_locally_signed_cert" "client" {
   ca_private_key_pem = "${join(" ", tls_private_key.etcd-ca.*.private_key_pem)}"
   ca_cert_pem        = "${join(" ", tls_self_signed_cert.etcd-ca.*.cert_pem)}"
 
-  validity_period_hours = 8760
+  validity_period_hours = "${var.certs_validity_period_hours}"
 
   allowed_uses = [
     "key_encipherment",
@@ -166,7 +166,7 @@ resource "tls_locally_signed_cert" "server" {
   ca_private_key_pem = "${join(" ", tls_private_key.etcd-ca.*.private_key_pem)}"
   ca_cert_pem        = "${join(" ", tls_self_signed_cert.etcd-ca.*.cert_pem)}"
 
-  validity_period_hours = 8760
+  validity_period_hours = "${var.certs_validity_period_hours}"
 
   allowed_uses = [
     "key_encipherment",
@@ -200,7 +200,7 @@ resource "tls_locally_signed_cert" "peer" {
   ca_private_key_pem = "${join(" ", tls_private_key.etcd-ca.*.private_key_pem)}"
   ca_cert_pem        = "${join(" ", tls_self_signed_cert.etcd-ca.*.cert_pem)}"
 
-  validity_period_hours = 8760
+  validity_period_hours = "${var.certs_validity_period_hours}"
 
   allowed_uses = [
     "key_encipherment",

--- a/tls-k8s.tf
+++ b/tls-k8s.tf
@@ -15,7 +15,7 @@ resource "tls_self_signed_cert" "kube-ca" {
   }
 
   is_ca_certificate     = true
-  validity_period_hours = 8760
+  validity_period_hours = "${var.certs_validity_period_hours}"
 
   allowed_uses = [
     "key_encipherment",
@@ -69,7 +69,7 @@ resource "tls_locally_signed_cert" "apiserver" {
   ca_private_key_pem = "${tls_private_key.kube-ca.private_key_pem}"
   ca_cert_pem        = "${tls_self_signed_cert.kube-ca.cert_pem}"
 
-  validity_period_hours = 8760
+  validity_period_hours = "${var.certs_validity_period_hours}"
 
   allowed_uses = [
     "key_encipherment",
@@ -113,7 +113,7 @@ resource "tls_locally_signed_cert" "admin" {
   ca_private_key_pem = "${tls_private_key.kube-ca.private_key_pem}"
   ca_cert_pem        = "${tls_self_signed_cert.kube-ca.cert_pem}"
 
-  validity_period_hours = 8760
+  validity_period_hours = "${var.certs_validity_period_hours}"
 
   allowed_uses = [
     "key_encipherment",
@@ -173,7 +173,7 @@ resource "tls_locally_signed_cert" "kubelet" {
   ca_private_key_pem = "${tls_private_key.kube-ca.private_key_pem}"
   ca_cert_pem        = "${tls_self_signed_cert.kube-ca.cert_pem}"
 
-  validity_period_hours = 8760
+  validity_period_hours = "${var.certs_validity_period_hours}"
 
   allowed_uses = [
     "key_encipherment",

--- a/variables.tf
+++ b/variables.tf
@@ -111,6 +111,12 @@ variable "trusted_certs_dir" {
   default     = "/usr/share/ca-certificates"
 }
 
+variable "certs_validity_period_hours" {
+  description = "Validity of all the certificates in hours"
+  type        = "string"
+  default     = 8760
+}
+
 variable "enable_aggregation" {
   description = "Enable the Kubernetes Aggregation Layer (defaults to false, recommended)"
   type        = "string"


### PR DESCRIPTION
Add a variable `certs_validity_period_hours` to parameterize the certs
validity in hours. Defaults to 8760 hours, which is 1 year.