### PR TITLE
Update to Kubernetes 1.16.2

### DIFF
--- a/resources/calico/cluster-role.yaml
+++ b/resources/calico/cluster-role.yaml
@@ -67,18 +67,19 @@ rules:
       - ipamblocks
       - globalnetworkpolicies
       - globalnetworksets
-      - networksets
       - networkpolicies
+      - networksets
       - clusterinformations
       - hostendpoints
+      - blockaffinities
     verbs:
       - get
       - list
       - watch
   - apiGroups: ["crd.projectcalico.org"]
     resources:
-      - felixconfigurations
       - ippools
+      - felixconfigurations
       - clusterinformations
     verbs:
       - create

--- a/resources/manifests/kube-apiserver.yaml
+++ b/resources/manifests/kube-apiserver.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       hostNetwork: true
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: kube-apiserver
       tolerations:

--- a/resources/manifests/kube-controller-manager.yaml
+++ b/resources/manifests/kube-controller-manager.yaml
@@ -37,7 +37,7 @@ spec:
                   - kube-controller-manager
               topologyKey: kubernetes.io/hostname
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
@@ -79,7 +79,7 @@ spec:
           readOnly: true
         - name: volumeplugins
           mountPath: /var/lib/kubelet/volumeplugins
-          readOnly: true          
+          readOnly: true
         - name: ssl-host
           mountPath: /etc/ssl/certs
           readOnly: true
@@ -92,5 +92,5 @@ spec:
           path: ${trusted_certs_dir}
       - name: volumeplugins
         hostPath:
-          path: /var/lib/kubelet/volumeplugins          
+          path: /var/lib/kubelet/volumeplugins
       dnsPolicy: Default # Don't use cluster DNS.

--- a/resources/manifests/kube-scheduler.yaml
+++ b/resources/manifests/kube-scheduler.yaml
@@ -37,7 +37,7 @@ spec:
                   - kube-scheduler
               topologyKey: kubernetes.io/hostname
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true

--- a/resources/manifests/pod-checkpointer.yaml
+++ b/resources/manifests/pod-checkpointer.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       hostNetwork: true
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node.kubernetes.io/master: ""
       priorityClassName: system-node-critical
       serviceAccountName: pod-checkpointer
       tolerations:

--- a/variables.tf
+++ b/variables.tf
@@ -88,8 +88,8 @@ variable "container_images" {
   type        = "map"
 
   default = {
-    calico           = "quay.io/calico/node:v3.8.2"
-    calico_cni       = "quay.io/calico/cni:v3.8.2"
+    calico           = "quay.io/calico/node:v3.9.1"
+    calico_cni       = "quay.io/calico/cni:v3.9.1"
     flannel          = "quay.io/coreos/flannel:v0.11.0-amd64"
     flannel_cni      = "quay.io/coreos/flannel-cni:v0.3.0"
     kube_router      = "cloudnativelabs/kube-router:v0.3.2"

--- a/variables.tf
+++ b/variables.tf
@@ -93,7 +93,7 @@ variable "container_images" {
     flannel          = "quay.io/coreos/flannel:v0.11.0-amd64"
     flannel_cni      = "quay.io/coreos/flannel-cni:v0.3.0"
     kube_router      = "cloudnativelabs/kube-router:v0.3.2"
-    hyperkube        = "k8s.gcr.io/hyperkube:v1.16.1"
+    hyperkube        = "k8s.gcr.io/hyperkube:v1.16.2"
     coredns          = "k8s.gcr.io/coredns:1.6.2"
     pod_checkpointer = "quay.io/coreos/pod-checkpointer:83e25e5968391b9eb342042c435d1b3eeddb2be1"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -88,8 +88,8 @@ variable "container_images" {
   type        = "map"
 
   default = {
-    calico           = "quay.io/calico/node:v3.9.1"
-    calico_cni       = "quay.io/calico/cni:v3.9.1"
+    calico           = "quay.io/calico/node:v3.9.2"
+    calico_cni       = "quay.io/calico/cni:v3.9.2"
     flannel          = "quay.io/coreos/flannel:v0.11.0-amd64"
     flannel_cni      = "quay.io/coreos/flannel-cni:v0.3.0"
     kube_router      = "cloudnativelabs/kube-router:v0.3.2"

--- a/variables.tf
+++ b/variables.tf
@@ -93,7 +93,7 @@ variable "container_images" {
     flannel          = "quay.io/coreos/flannel:v0.11.0-amd64"
     flannel_cni      = "quay.io/coreos/flannel-cni:v0.3.0"
     kube_router      = "cloudnativelabs/kube-router:v0.3.2"
-    hyperkube        = "k8s.gcr.io/hyperkube:v1.15.3"
+    hyperkube        = "k8s.gcr.io/hyperkube:v1.16.1"
     coredns          = "k8s.gcr.io/coredns:1.6.2"
     pod_checkpointer = "quay.io/coreos/pod-checkpointer:83e25e5968391b9eb342042c435d1b3eeddb2be1"
   }


### PR DESCRIPTION
- Update Kubernetes to 1.16.2
- Update Calico to 3.9.2
- Remove labels `node-role.kubernetes.io`, kubelet cannot set these labels using the flag --node-labels. This is enforced as a security feature. But this can be set manually by cluster-admin.