### PR TITLE
kube-proxy: Switch from iptables to ipvs

### DIFF
--- a/resources/manifests/kube-proxy.yaml
+++ b/resources/manifests/kube-proxy.yaml
@@ -40,7 +40,7 @@ spec:
         - --cluster-cidr=${pod_cidr}
         - --hostname-override=$(NODE_NAME)
         - --kubeconfig=/etc/kubernetes/kubeconfig
-        - --proxy-mode=iptables
+        - --proxy-mode=ipvs
         env:
           - name: NODE_NAME
             valueFrom:


### PR DESCRIPTION
* IPVS is more scalable than iptables.
* It was introduced with Kubernetes 1.11 and is considered stable.
