### PR TITLE
calico: Upgrade from 3.10.0 to 3.10.1

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -88,8 +88,8 @@ variable "container_images" {
   type        = "map"
 
   default = {
-    calico           = "quay.io/calico/node:v3.10.0"
-    calico_cni       = "quay.io/calico/cni:v3.10.0"
+    calico           = "quay.io/calico/node:v3.10.1"
+    calico_cni       = "quay.io/calico/cni:v3.10.1"
     flannel          = "quay.io/coreos/flannel:v0.11.0-amd64"
     flannel_cni      = "quay.io/coreos/flannel-cni:v0.3.0"
     kube_router      = "cloudnativelabs/kube-router:v0.3.2"


### PR DESCRIPTION
* Upgrade Calico from v3.10.0 to v3.10.1
* Release Notes: https://docs.projectcalico.org/v3.10/release-notes#v3.10.1