### PR TITLE
Support multi-arch container images

### DIFF
--- a/assets.tf
+++ b/assets.tf
@@ -21,7 +21,7 @@ resource "template_dir" "manifests" {
   vars {
     hyperkube_image         = "${var.container_images["hyperkube"]}"
     pod_checkpointer_image  = "${var.container_images["pod_checkpointer"]}"
-    coredns_image           = "${var.container_images["coredns"]}"
+    coredns_image           = "${var.container_images["coredns"]}${var.container_arch}"
     etcd_servers            = "${join(",", formatlist("https://%s:2379", var.etcd_servers))}"
     control_plane_replicas  = "${max(2, length(var.etcd_servers))}"
     cloud_provider          = "${var.cloud_provider}"

--- a/conditional.tf
+++ b/conditional.tf
@@ -6,7 +6,7 @@ resource "template_dir" "flannel-manifests" {
   destination_dir = "${var.asset_dir}/manifests-networking"
 
   vars {
-    flannel_image     = "${var.container_images["flannel"]}"
+    flannel_image     = "${var.container_images["flannel"]}${var.container_arch}"
     flannel_cni_image = "${var.container_images["flannel_cni"]}"
     pod_cidr          = "${var.pod_cidr}"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -83,19 +83,27 @@ variable "cluster_domain_suffix" {
   default     = "cluster.local"
 }
 
+variable "container_arch" {
+  description = "Architecture suffix for the container images coredns/coredns:coredns- and quay.io/coreos/flannel:v0.11.0- (e.g., arm64)"
+  type        = "string"
+  default     = "amd64"
+}
+
 variable "container_images" {
-  description = "Container images to use"
+  description = "Container images to use (the coredns and flannel entry will get -${var.container_arch} appended)"
   type        = "map"
 
   default = {
-    calico           = "quay.io/calico/node:v3.10.1"
-    calico_cni       = "quay.io/calico/cni:v3.10.1"
-    flannel          = "quay.io/coreos/flannel:v0.11.0-amd64"
+    calico           = "calico/node:v3.10.1"
+    calico_cni       = "calico/cni:v3.10.1"
+    flannel          = "quay.io/coreos/flannel:v0.11.0-"
+    # only amd64 images available for flannel_cni
     flannel_cni      = "quay.io/coreos/flannel-cni:v0.3.0"
+    # only amd64 images available for cloudnativelabs/kube-router
     kube_router      = "cloudnativelabs/kube-router:v0.3.2"
     hyperkube        = "k8s.gcr.io/hyperkube:v1.16.2"
-    coredns          = "k8s.gcr.io/coredns:1.6.2"
-    pod_checkpointer = "quay.io/coreos/pod-checkpointer:83e25e5968391b9eb342042c435d1b3eeddb2be1"
+    coredns          = "coredns/coredns:coredns-"
+    pod_checkpointer = "kinvolk/pod-checkpointer:83e25e5968391b9eb342042c435d1b3eeddb2be1"
   }
 }
 


### PR DESCRIPTION
Where possible we switch to multi-arch container images.
If they are not available, we use explicit suffixes for the
architectures by introducing a new variable for the architecture.
Some images are amd64-only and won't be available for non-x86 nodes.