### PR TITLE
coredns: Add health plugin lameduck

### DIFF
--- a/resources/manifests/coredns/config.yaml
+++ b/resources/manifests/coredns/config.yaml
@@ -7,7 +7,9 @@ data:
   Corefile: |
     .:53 {
         errors
-        health
+        health {
+          lameduck 5s
+        }
         ready
         log . {
             class error


### PR DESCRIPTION
When `lameduck 5s`, coredns reports unhealthy and waits for 5s before
shutdown. This enables other plugins to shutdown gracefully.
