### PR TITLE
Fix typo error in clusterDomainSuffix in coredns config

### DIFF
--- a/resources/charts/kubernetes/templates/coredns-config.yaml
+++ b/resources/charts/kubernetes/templates/coredns-config.yaml
@@ -14,7 +14,7 @@ data:
         log . {
             class error
         }
-        kubernetes {{ .Values.coredns.clusterDomainSufix }} in-addr.arpa ip6.arpa {
+        kubernetes {{ .Values.coredns.clusterDomainSuffix }} in-addr.arpa ip6.arpa {
             pods insecure
             fallthrough in-addr.arpa ip6.arpa
         }


### PR DESCRIPTION
- Spelling error in the value `clusterDomainSufix` led to dns problems
  in clusters created using bootkube with helm.

  This problem was found out when envoy pods were not in running state
  after installing contour.

Signed-off-by: Imran Pochi <imran@kinvolk.io>